### PR TITLE
2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   Changed instance `problem` property to use private `#problem`.  
   Changed public static `defineMessage()` method to use private static `#guardMessage()` to guards the provided `message`.  
   Changed constructor to use public `setMessage()` method and add new `callback` parameter to handle private instance of `Callback`.  
-- [`0708846`][0708846] [`bcc6521`][bcc6521] [`0bbd886`][0bbd886]
+- [`0708846`][0708846] [`bcc6521`][bcc6521] [`0bbd886`][0bbd886]  
   Updated `README.md`.
 
 [0bbd886]: https://github.com/angular-package/error/commit/0bbd88630e0a695ab4865903c83bda7b2e56dfef

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.0] - 2021-08-12
+
+### 2.0.0 Added
+
+- [`069d111`][069d111]  
+  Added static private property `#template` of a `string` type.  
+  Added private instance `#callback` property of `Callback` instance.  
+  Added private instance `#fix`,  `#problem`, `#tpl` property.  
+  Added pubic methods `setFix()`, `setMessage()`, `setProblem()`,  `setTemplate()`, `throw()`, `updateMessage()` of an instance.  
+  Added static private methods `#guardMessage()`, `#guardTemplate()`.  
+- [`4040750`][4040750]  
+  Added an optional property `template` to the `ErrorMessage` interface.
+- [`0d5cc92`][0d5cc92]  
+  Added `VEAllowedCallback` type of allowed names for internal instance of `Callback`.
+
+[069d111]: https://github.com/angular-package/error/commit/069d111220b63c2d2cdbffa499f3588121f14e16
+[4040750]: https://github.com/angular-package/error/commit/40407503893484874e588b8b5b42c6e40a5fc3ab
+[0d5cc92]: https://github.com/angular-package/error/commit/0d5cc920b7e5c750f77099580ec2f53070d3cac7
+
+### 2.0.0 Changed
+
+- [`069d111`][069d111]  
+  Changed static public `template` property to use static private `#template` property that is guarded by the private static `#guardTemplate()` method.  
+  Changed instance `fix` property to use private `#fix`.  
+  Changed instance `problem` property to use private `#problem`.  
+  Changed public static `defineMessage()` method to use private static `#guardMessage()` to guards the provided `message`.  
+  Changed constructor to use public `setMessage()` method and add new `callback` parameter to handle private instance of `Callback`.  
+- [`0708846`][0708846] [`bcc6521`][bcc6521] [`0bbd886`][0bbd886]
+  Updated `README.md`.
+
+[0bbd886]: https://github.com/angular-package/error/commit/0bbd88630e0a695ab4865903c83bda7b2e56dfef
+[bcc6521]: https://github.com/angular-package/error/commit/bcc652139613a7f8ef721cd12bc076fde3edadb8
+[0708846]: https://github.com/angular-package/error/commit/0708846f6bc3de0fa080e5f58fa4a36adfcb7dcd
+
 ## [1.0.3] - 2021-08-06
 
 ### 1.0.3 Added

--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ public setFix(
 | Name: type                                   | Description |
 | :------------------------------------------- | :---------- |
 | `fix: string`                                | A possible solution to the described problem guarded by a [`string`][js-string] type. |
-| `callback?: ResultCallback<CallbackPayload>` | An optional callback function of [`ResultCallback`][package-callback-resultcallback] type to handle the check whether the provided [`fix`][error-property-fix] is a [`string`][js-string]. It can be initially set by callback |
+| `callback?: ResultCallback<CallbackPayload>` | An optional callback function of [`ResultCallback`][package-callback-resultcallback] type to handle the check whether the provided [`fix`][error-property-fix] is a [`string`][js-string]. By default, it uses an internal callback under the `'setFix'` name, which can be initially set by the optional `callback` parameter that gives access to the internal instance of [`Callback`][callback-github-readme]. |
 
 **Returns:**
 
@@ -611,7 +611,7 @@ public setMessage(
 | Name: type                                   | Description |
 | :------------------------------------------- | :---------- |
 | `message: string \| ErrorMessage`            | An object of an [`ErrorMessage`](#errormessage) interface to build the message of a [`string`][js-string] type. The value is checked against the proper `object`. |
-| `callback?: ResultCallback<CallbackPayload>` | An optional callback function of [`ResultCallback`][package-callback-resultcallback] type to handle the check whether the provided `message` is a [`string`][js-string] type or whether it's an object that contains required [`problem`][error-property-problem] and [`fix`][error-property-fix] properties or whether it's a [`string`][js-string] type. |
+| `callback?: ResultCallback<CallbackPayload>` | An optional callback function of [`ResultCallback`][package-callback-resultcallback] type to handle the check whether the provided `message` is a [`string`][js-string] type or whether it's an object that contains required [`problem`][error-property-problem] and [`fix`][error-property-fix] properties. By default, it uses an internal callback under the `'setMessage'` name, which can be initially set by the optional `callback` parameter that gives access to the internal instance of [`Callback`][callback-github-readme]. |
 
 **Returns:**
 
@@ -681,7 +681,7 @@ public setProblem(
 | Name: type                                   | Description |
 | :------------------------------------------- | :---------- |
 | `fix: string`                                | A possible solution to the described [`problem`][error-property-problem] guarded by a [`string`][js-string] type. |
-| `callback?: ResultCallback<CallbackPayload>` | An optional callback function of [`ResultCallback`][package-callback-resultcallback] type to handle the check whether the provided `fix` is a [`string`][js-string]. |
+| `callback?: ResultCallback<CallbackPayload>` | An optional callback function of [`ResultCallback`][package-callback-resultcallback] type to handle the check whether the provided `fix` is a [`string`][js-string]. By default, it uses an internal callback under the `'setProblem'` name, which can be initially set by the optional `callback` parameter that gives access to the internal instance of [`Callback`][callback-github-readme]. |
 
 **Returns:**
 
@@ -750,7 +750,7 @@ public setTemplate(
 | Name: type                                   | Description |
 | :------------------------------------------- | :---------- |
 | `template: string`                           | A message [`template`][error-property-template] guarded by a [`string`][js-string] type with replaceable `[problem]` and `[fix]` words. |
-| `callback?: ResultCallback<CallbackPayload>` | An optional callback function of [`ResultCallback`][package-callback-resultcallback] type to handle the check whether the provided `template` is a [`string`][js-string] that contains `[fix]` and `[problem]` words. |
+| `callback?: ResultCallback<CallbackPayload>` | An optional callback function of [`ResultCallback`][package-callback-resultcallback] type to handle the check whether the provided `template` is a [`string`][js-string] that contains `[fix]` and `[problem]` words. By default, it uses an internal callback under the `'setTemplate'` name, which can be initially set by the optional `callback` parameter that gives access to the internal instance of [`Callback`][callback-github-readme]. |
 
 **Returns:**
 

--- a/README.md
+++ b/README.md
@@ -986,7 +986,7 @@ An optional message template of a [`string`][js-string] type.
 
 <br>
 
-## Interface
+## Type
 
 #### `VEAllowedCallback`
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ Manages an [`Error`][js-error] of validation.
 
 #### `ValidationError.template`
 
+![update]
+
 A template of the error message guarded by [`string`][js-string] type with the replaceable `[problem]` and `[fix]` words. By default, it's set to `Problem: [problem] => Fix: [fix]`.
 
 ```typescript
@@ -210,6 +212,8 @@ static set template(value: string) {
 ----
 
 #### `ValidationError.prototype.fix`
+
+![update]
 
 A possible solution to the described [`problem`][error-property-problem] of validation that is guarded by a [`string`][js-string] type. By default, it's an empty [`string`][js-string].
 
@@ -241,6 +245,8 @@ public get message(): string {
 
 #### `ValidationError.prototype.name`
 
+![update]
+
 Error name of a [`string`][js-string] type that is being thrown. By default, it's ['ValidationError'](#validationerror).
 
 ```typescript
@@ -250,6 +256,8 @@ public name = ValidationError.name;
 <br>
 
 #### `ValidationError.prototype.problem`
+
+![update]
 
 Description of a validation [`problem`][error-property-problem] guarded by a [`string`][js-string] type. By default, it's an empty [`string`][js-string].
 
@@ -387,6 +395,8 @@ const errorMessage = ValidationError.defineMessage(
 ----
 
 #### `ValidationError()`
+
+![update]
 
 Creates a new instance with the message. If the provided `message` is an [`object`][js-object], then its properties are assigned to the instance.
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ Manages an [`Error`][js-error] of validation.
 
 ![update]
 
+[2.0.0]: Uses static private property `#template` and guards the value with private static method `#guardTemplate()` to be `string` type that contains `[fix]` and `[problem]` words.
+
 A template of the error message guarded by [`string`][js-string] type with the replaceable `[problem]` and `[fix]` words. By default, it's set to `Problem: [problem] => Fix: [fix]`. It can be set directly or by the [`setTemplate()`][error-method-settemplate] and [`setMessage()`][error-method-setmessage] method. The value is being checked against the existence of `[problem]` and `[fix]` words.
 
 ```typescript
@@ -218,6 +220,8 @@ static set template(value: string) {
 
 ![update]
 
+[2.0.0]: Uses static private property `#fix` and guards the value to be a [`string`][js-string] type.
+
 A possible solution to the described [`problem`][error-property-problem] of validation that is guarded by a [`string`][js-string] type. By default, it's an empty [`string`][js-string]. It can be set directly or by the [`setFix()`][error-method-setfix] and [`setMessage()`][error-method-setmessage] method.
 
 ```typescript
@@ -234,6 +238,8 @@ public set fix(value: string) {
 #### `ValidationError.prototype.message`
 
 ![update]
+
+[2.0.0]: Uses inherited from `Error` property and guards the value to be a [`string`][js-string] type.
 
 A validation error message guarded by a [`string`][js-string] type that can be build from the [`problem`][error-property-problem] and [`fix`][error-property-fix] of [`ValidationError`](#validationerror) on the [`template`][error-property-template]. It can be set directly or by the [`throw()`][error-method-throw] and [`setMessage()`][error-method-setmessage] method.
 
@@ -282,6 +288,8 @@ public set problem(value: string) {
 #### `ValidationError.defineMessage()`
 
 ![update]
+
+[2.0.0]: Adds template to the provided `message` instead of separate parameter and guards it with a static `#guardMessage()` method.
 
 Defines the validation error message of a [`string`][js-string] type from the provided `message` of the [`ErrorMessage`](#errormessage) interface.
 
@@ -400,6 +408,8 @@ const errorMessage = ValidationError.defineMessage(
 #### `ValidationError()`
 
 ![update]
+
+[2.0.0]: Adds template to the provided `message` instead of separate parameter and uses a new method [`setMessage()`][error-method-setmessage] to set message. Handle the callback for all instance methods with the callback parameter.
 
 Creates a new instance with the message. If the provided `message` is an [`object`][js-object], then its properties are assigned to the instance.
 
@@ -963,6 +973,10 @@ addPerson({
 
 #### `ErrorMessage`
 
+![update]
+
+[2.0.0]: Adds an optional `template` property.
+
 The shape of an [`object`][js-object] for an [`error`][js-error] message that contains a possible solution to the described problem.
 
 ```typescript
@@ -982,6 +996,7 @@ Possible solution to the described problem of a [`string`][js-string] type.
 Description of validation problem of a [`string`][js-string] type.
 
 **`template?: string`**  
+![new]  
 An optional message template of a [`string`][js-string] type.
 
 <br>

--- a/README.md
+++ b/README.md
@@ -152,10 +152,17 @@ Manages an [`Error`][js-error] of the validation.
 
 #### `ValidationError.template`
 
-Template of the error message with the replaceable `[problem]` and `[fix]`. By default, it's set to `Problem: [problem] => Fix: [fix]`.
+A template of the error message guarded by [`string`][js-string] type with the replaceable `[problem]` and `[fix]`. By default, it's set to `Problem: [problem] => Fix: [fix]`.
 
 ```typescript
-static template = `Problem: [problem] => Fix: [fix]`;
+static get template(): string {
+  return this.#template;
+}
+static set template(value: string) {
+  if (guard.string(value)) {
+    this.#template = value;
+  }
+}
 ```
 
 <br>
@@ -248,6 +255,57 @@ const problem = 'The problem has no solution.';
 const errorMessage = ValidationError.defineMessage({ fix, problem });
 ```
 
+```typescript
+// Example usage: create an error message of a string type from the provided object with a different template.
+import { ValidationError } from '@angular-package/error';
+
+const fix = 'There is no solution to the described problem.';
+const problem = 'The problem has no solution.';
+const template = `[problem] ... [fix]`;
+
+/**
+ * Returns
+ * --------
+ * The problem has no solution. ... There is no solution to the described problem.
+ */
+const errorMessage = ValidationError.defineMessage({ fix, problem, template });
+```
+
+```typescript
+// Example usage: create an error message of a string type from the provided object and the changed template.
+import { ValidationError } from '@angular-package/error';
+
+// Change the template by directly assign a new value.
+ValidationError.template = `\nPROBLEM: [problem]\nFIX: [fix] `;
+
+const fix = 'There is no solution to the described problem.';
+const problem = 'The problem has no solution.';
+
+/**
+ * Returns
+ * --------
+ * PROBLEM: The problem has no solution.
+ * FIX: There is no solution to the described problem. 
+ */
+const errorMessage = ValidationError.defineMessage({ fix, problem });
+```
+
+```typescript
+// Example usage: create an error message of a string type from the provided object and the changed template.
+import { ValidationError } from '@angular-package/error';
+
+const fix = 'There is no solution to the described problem.';
+const problem = 'The problem has no solution.';
+
+const errorMessage = ValidationError.defineMessage(
+  { fix, problem },
+  (result, payload) => {
+    // Do something with the `result` of the `message` check and `payload`.
+    return result;
+  }
+);
+```
+
 <br>
 
 ### `ValidationError` constructor
@@ -291,6 +349,14 @@ import { ValidationError } from '@angular-package/error';
 const fix = 'There is no solution to the described problem.';
 const problem = 'The problem has no solution.';
 const validationError = new ValidationError({ fix, problem });
+```
+
+<br>
+
+### Complete usage of `ValidationError`
+
+```typescript
+//
 ```
 
 <br>
@@ -355,7 +421,7 @@ import { MessageBuilder } from '@angular-package/error';
  */
 const messageMethodBuilder = new MessageBuilder('method');
 
-// Build the class method.
+// Build the method of any class.
 messageMethodBuilder
   .setMethodName('setPerson')
   .setParam('value', 'string')
@@ -374,7 +440,7 @@ import { MessageBuilder } from '@angular-package/error';
  */
 const messageClassBuilder = new MessageBuilder('class');
 
-// Build the class.
+// Build the method of a specified class.
 messageClassBuilder
   .setClassName('Person.prototype.')
   .setMethodName('setPerson')

--- a/README.md
+++ b/README.md
@@ -130,19 +130,57 @@ import {
 
 ## `ValidationError`
 
-Manages an [`Error`][js-error] of the validation.
+Manages an [`Error`][js-error] of validation.
+
+**Static properties:**
+
+| ValidationError.                              | Description |
+| :-------------------------------------------- | :---------- |
+| [`template: string`][error-property-template] | A template of the error message guarded by a [`string`][js-string] type with the replaceable `[problem]` and `[fix]` words.  By default, it's set to `'Problem: [problem] => Fix: [fix]'`. |
+
+[error-property-template]: #validationerrortemplate
+
+**Instance properties:**
+
+| ValidationError.prototype.                  | Description |
+| :------------------------------------------ | :---------- |
+| [`fix: string`][error-property-fix]         | A possible solution to the described [`problem`][error-property-problem] of validation that is guarded by a [`string`][js-string] type. |
+| [`message: string`][error-property-message] | A validation error message guarded by a [`string`][js-string] type that can be built with the [`problem`][error-property-problem] and [`fix`][error-property-fix] of [`ValidationError`](#validationerror) by the [`throw()`][error-method-throw] and [`setMessage()`][error-method-setmessage] method. |
+| [`name: string`][error-property-name]       | Error name of a [`string`][js-string] type that is being thrown. |
+| [`problem: string`][error-property-problem] | Description of a validation problem guarded by a [`string`][js-string] type. |
+
+[error-property-fix]: #validationerrorprototypefix
+[error-property-message]: #validationerrorprototypemessage
+[error-property-name]: #validationerrorprototypename
+[error-property-problem]: #validationerrorprototypeproblem
 
 **Static methods:**
 
 | ValidationError.                                   | Description |
 | :------------------------------------------------- | :---------- |
-| [`defineMessage()`](#validationerrordefinemessage) | Defines the validation error message of a [`string`][js-string] type from the provided `message` of the [`ErrorMessage`](#errormessage) interface |
+| [`defineMessage()`](#validationerrordefinemessage) | Defines the validation error message of a [`string`][js-string] type from the provided `message` of the [`ErrorMessage`](#errormessage) interface. |
 
 **Constructor:**
 
 | Constructor                                         | Description |
 | :-------------------------------------------------- | :---------- |
-| [`ValidationError()`](#validationerror-constructor) | Creates a new instance with the message. If the provided `message` is an [`object`][js-object], then its properties are assigned to the instance |
+| [`ValidationError()`](#validationerror-constructor) | Creates a new instance with the message. If the provided `message` is an [`object`][js-object], then its properties are assigned to the instance. |
+
+**Instance methods:**
+
+| ValidationError.prototype.                  | Description |
+| :------------------------------------------ | :---------- |
+| [`setFix()`][error-method-setfix]           | Sets the fix a possible solution to the described [`problem`][error-property-problem]. |
+| [`setMessage()`][error-method-setmessage]   | Sets the validation error message of a [`string`][js-string] type from the provided `message` of the [`ErrorMessage`](#errormessage) interface. |
+| [`setProblem()`][error-method-setproblem]   | Sets description problem of a [`ValidationError`](#validationerror). |
+| [`setTemplate()`][error-method-settemplate] | Sets the template of validation error message. |
+| [`throw()`][error-method-throw]             | Throws an error of [`ValidationError`](#validationerror) with actual settings. |
+
+[error-method-setfix]: #validationerrorprototypesetfix
+[error-method-setmessage]: #validationerrorprototypesetmessage
+[error-method-setproblem]: #validationerrorprototypesetproblem
+[error-method-settemplate]: #validationerrorprototypesettemplate
+[error-method-throw]: #validationerrorprototypethrow
 
 <br>
 
@@ -152,16 +190,16 @@ Manages an [`Error`][js-error] of the validation.
 
 #### `ValidationError.template`
 
-A template of the error message guarded by [`string`][js-string] type with the replaceable `[problem]` and `[fix]`. By default, it's set to `Problem: [problem] => Fix: [fix]`.
+A template of the error message guarded by [`string`][js-string] type with the replaceable `[problem]` and `[fix]` words. By default, it's set to `Problem: [problem] => Fix: [fix]`.
 
 ```typescript
 static get template(): string {
-  return this.#template;
+  return ValidationError.#template;
 }
 static set template(value: string) {
-  if (guard.string(value)) {
-    this.#template = value;
-  }
+  ValidationError.#template = ValidationError.#guardTemplate(value)
+    ? value
+    : ValidationError.#template;
 }
 ```
 
@@ -173,17 +211,37 @@ static set template(value: string) {
 
 #### `ValidationError.prototype.fix`
 
-A possible solution to the described problem of a [`string`][js-string] type. By default, it's an empty [`string`][js-string].
+A possible solution to the described [`problem`][error-property-problem] of validation that is guarded by a [`string`][js-string] type. By default, it's an empty [`string`][js-string].
 
 ```typescript
-public fix = '';
+public get fix(): string {
+  return this.#fix;
+}
+public set fix(value: string) {
+  this.#fix = guard.string(value) ? value : this.#fix;
+}
+```
+
+<br>
+
+#### `ValidationError.prototype.message`
+
+A validation error message guarded by a [`string`][js-string] type that can be build from the [`problem`][error-property-problem] and [`fix`][error-property-fix] of [`ValidationError`](#validationerror) on the [`template`][error-property-template].
+
+```typescript
+public set message(value: string) {
+  super.message = guard.string(value) ? value : super.message;
+}
+public get message(): string {
+  return super.message;
+}
 ```
 
 <br>
 
 #### `ValidationError.prototype.name`
 
-Error name of a [`string`][js-string] type that is being thrown. By default, it's [`ValidationError`](#validationerror).
+Error name of a [`string`][js-string] type that is being thrown. By default, it's ['ValidationError'](#validationerror).
 
 ```typescript
 public name = ValidationError.name;
@@ -193,10 +251,15 @@ public name = ValidationError.name;
 
 #### `ValidationError.prototype.problem`
 
-The validation problem of a [`string`][js-string] type. By default, it's an empty [`string`][js-string].
+Description of a validation [`problem`][error-property-problem] guarded by a [`string`][js-string] type. By default, it's an empty [`string`][js-string].
 
 ```typescript
-public problem = '';
+public get problem(): string {
+  return this.#problem;
+}
+public set problem(value: string) {
+  this.#problem = guard.string(value) ? value : this.#problem;
+}
 ```
 
 <br>
@@ -207,22 +270,20 @@ public problem = '';
 
 #### `ValidationError.defineMessage()`
 
+![update]
+
 Defines the validation error message of a [`string`][js-string] type from the provided `message` of the [`ErrorMessage`](#errormessage) interface.
 
 ```typescript
-static defineMessage(
+public static defineMessage(
   message: ErrorMessage,
-  template: string = ValidationError.template,
-  callback?: ResultCallback
+  callback?: ResultCallback<CallbackPayload & ErrorMessage>
 ): string {
-  if (is.objectKey(message, ['fix', 'problem'], callback)) {
-    if (is.string(template)) {
-      return template
+  return ValidationError.#guardMessage(message, callback)
+    ? (message.template || ValidationError.template)
         .replace(`[fix]`, message.fix)
-        .replace(`[problem]`, message.problem);
-    }
-  }
-  return '';
+        .replace(`[problem]`, message.problem)
+    : '';
 }
 ```
 
@@ -232,11 +293,11 @@ static defineMessage(
 | :-------------------------- | :---------- |
 | `message: ErrorMessage`     | An [`object`][js-object] of the [`ErrorMessage`](#errormessage) interface to build a message of a [`string`][js-string] type. The value is checked against the proper [`object`][js-object] |
 | `template: string`          | A message template of a [`string`][js-string] type with replaceable `[problem]` and `[fix]` from the given `message`. The value is checked against a [`string`][js-string]. By default, it's set to `Problem: [problem] => Fix: [fix]` |
-| `callback?: ResultCallback` | An optional callback function of [`ResultCallback`][package-type-resultcallback] type to handle the check whether the provided message contains required `problem` and `fix` properties |
+| `callback?: ResultCallback` | An optional callback function of [`ResultCallback`][package-callback-resultcallback] type to handle the check whether the provided message contains required `problem` and `fix` properties |
 
 **Returns:**
 
-The **return value** is a message of a `string` type created from the provided `message` of [`ErrorMessage`](#errormessage) interface, or it's an empty [`string`][js-string] if the provided message [`object`][js-object] isn't proper.
+The **return value** is a message of a [`string`][js-string] type created from the provided `message` of [`ErrorMessage`](#errormessage) interface, or it's an empty [`string`][js-string] if the provided message [`object`][js-object] isn't proper.
 
 **Usage:**
 
@@ -247,51 +308,63 @@ import { ValidationError } from '@angular-package/error';
 const fix = 'There is no solution to the described problem.';
 const problem = 'The problem has no solution.';
 
-/**
- * Returns
- * --------
- * Problem: The problem has no solution. => Fix: There is no solution to the described problem.
- */
+/*
+  Returns
+  --------
+  Problem: The problem has no solution. => Fix: There is no solution
+  to the described problem.
+*/
 const errorMessage = ValidationError.defineMessage({ fix, problem });
 ```
 
 ```typescript
-// Example usage: create an error message of a string type from the provided object with a different template.
+/*
+  Example usage: create an error message of a string type
+  from the provided object with a different template.
+*/
 import { ValidationError } from '@angular-package/error';
 
 const fix = 'There is no solution to the described problem.';
 const problem = 'The problem has no solution.';
 const template = `[problem] ... [fix]`;
 
-/**
- * Returns
- * --------
- * The problem has no solution. ... There is no solution to the described problem.
- */
-const errorMessage = ValidationError.defineMessage({ fix, problem, template });
+/*
+  Returns
+  --------
+  The problem has no solution. ... There is no solution to the described problem.
+*/
+const errorMessage = ValidationError.defineMessage({
+  fix, problem, template
+});
 ```
 
 ```typescript
-// Example usage: create an error message of a string type from the provided object and the changed template.
+/*
+  Example usage: create an error message of a string type
+  from the provided object and the changed template.
+*/
 import { ValidationError } from '@angular-package/error';
-
-// Change the template by directly assign a new value.
-ValidationError.template = `\nPROBLEM: [problem]\nFIX: [fix] `;
 
 const fix = 'There is no solution to the described problem.';
 const problem = 'The problem has no solution.';
 
-/**
- * Returns
- * --------
- * PROBLEM: The problem has no solution.
- * FIX: There is no solution to the described problem. 
- */
+// Change the template by directly assign a new value.
+ValidationError.template = `\nPROBLEM: [problem]\nFIX: [fix] `;
+
+/*
+  Returns
+  -------
+  PROBLEM: The problem has no solution.
+  FIX: There is no solution to the described problem. 
+*/
 const errorMessage = ValidationError.defineMessage({ fix, problem });
 ```
 
 ```typescript
-// Example usage: create an error message of a string type from the provided object and the changed template.
+/*
+  Example usage: create an error message of a string type
+  from the provided object and the changed template.
+*/
 import { ValidationError } from '@angular-package/error';
 
 const fix = 'There is no solution to the described problem.';
@@ -300,7 +373,8 @@ const problem = 'The problem has no solution.';
 const errorMessage = ValidationError.defineMessage(
   { fix, problem },
   (result, payload) => {
-    // Do something with the `result` of the `message` check and `payload`.
+    // Do something with the `result` of the `message` check
+    // and `payload`.
     return result;
   }
 );
@@ -317,16 +391,19 @@ const errorMessage = ValidationError.defineMessage(
 Creates a new instance with the message. If the provided `message` is an [`object`][js-object], then its properties are assigned to the instance.
 
 ```typescript
-new ValidationError(message: string | ErrorMessage) {
-  super(
-    is.string(message) ? message : ValidationError.defineMessage(message)
-  );
-  if (is.object(message)) {
-    Object.assign(this, {
-      problem: message.problem,
-      fix: message.fix,
-    });
+constructor(
+  message: string | ErrorMessage = '',
+  callback?: (callback: Callback<AllowedCallback>) => void
+) {
+  super();
+
+  // Sets the callback for an instance methods.
+  if (is.function(callback)) {
+    callback(this.#callback);
   }
+
+  // Initializes the message and assigns message properties `fix`, `problem` and optionally `template` to a new instance.
+  this.setMessage(message);
 }
 ```
 
@@ -334,7 +411,8 @@ new ValidationError(message: string | ErrorMessage) {
 
 | Name: type                        | Description |
 | :-------------------------------- | :---------- |
-| `message: string \| ErrorMessage` | The message of a [`string`][js-string] type or of an [`ErrorMessage`](#errormessage) interface that is used to throw with an [`error`][js-error] |
+| `message: string \| ErrorMessage` | The message of a [`string`][js-string] type or of an [`ErrorMessage`](#errormessage) interface that is used to throw with an [`Error`][js-error]. |
+| `callback?: (callback: Callback<AllowedCallback>) => void` | An optional function to handle the internal instance of [`Callback`][callback-github-readme]. |
 
 **Returns:**
 
@@ -348,7 +426,360 @@ import { ValidationError } from '@angular-package/error';
 
 const fix = 'There is no solution to the described problem.';
 const problem = 'The problem has no solution.';
+
 const validationError = new ValidationError({ fix, problem });
+```
+
+```typescript
+// Example usage with callback.
+
+```
+
+<br>
+
+### `ValidationError` instance public methods
+
+----
+
+#### `ValidationError.prototype.setFix()`
+
+![new]
+
+Sets the [`fix`][error-property-fix] a possible solution to the described [`problem`][error-property-problem].
+
+```typescript
+// Syntax.
+public setFix(
+  fix: string,
+  callback: ResultCallback<CallbackPayload> = this.#callback.getCallback(
+    'setFix'
+  )
+): this {
+  if (guard.string(fix, callback)) {
+    this.#fix = fix;
+  }
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                                   | Description |
+| :------------------------------------------- | :---------- |
+| `fix: string`                                | A possible solution to the described problem guarded by a [`string`][js-string] type. |
+| `callback?: ResultCallback<CallbackPayload>` | An optional callback function of [`ResultCallback`][package-callback-resultcallback] type to handle the check whether the provided [`fix`][error-property-fix] is a [`string`][js-string]. |
+
+**Returns:**
+
+The **return value** is an instance of an [`ValidationError`](#validationerror).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { ValidationError } from '@angular-package/error';
+
+// Initialize an instance.
+const validationError = new ValidationError();
+
+// Define a fix.
+const fix = 'There is no solution to the described problem.';
+
+// Returns 'There is no solution to the described problem.'
+validationError.setFix(fix).fix;
+```
+
+```typescript
+// Example usage with a callback.
+import { ValidationError } from '@angular-package/error';
+
+// Initialize an instance.
+const validationError = new ValidationError();
+
+// Define a fix.
+const fix = 'There is no solution to the described problem.';
+
+// Set the fix and handle the check of it with a callback.
+validationError.setFix(fix, (result, payload) => {
+  // Returns `true`.
+  result;
+  // Returns `There is no solution to the described problem.`.
+  payload;
+  return result;
+});
+```
+
+<br>
+
+#### `ValidationError.prototype.setMessage()`
+
+![new]
+
+Sets the validation error message of a [`string`][js-string] type from the provided `message` of the [`ErrorMessage`](#errormessage) interface.
+
+```typescript
+// Syntax.
+public setMessage(
+  message: string | ErrorMessage,
+  callback: ResultCallback<
+    CallbackPayload & ErrorMessage
+  > = this.#callback.getCallback('setMessage')
+): this {
+  this.message = is.string(message, callback)
+    ? // Sets a message of a string type from the provided message of `string`.
+      message
+    : // Sets a message of a string type from the provided message of `ErrorMessage`.
+      ValidationError.defineMessage(message, callback);
+
+  // Sets `fix`, `problem` and optionally `template` from the provided `message`.
+  if (is.object(message)) {
+    this.setFix(message.fix).setProblem(message.problem);
+    if (is.defined(message.template)) {
+      this.setTemplate(message.template);
+    }
+  }
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                                   | Description |
+| :------------------------------------------- | :---------- |
+| `message: string \| ErrorMessage`            | An object of an [`ErrorMessage`](#errormessage) interface to build the message of a [`string`][js-string] type. The value is checked against the proper `object`. |
+| `callback?: ResultCallback<CallbackPayload>` | An optional callback function of [`ResultCallback`][package-callback-resultcallback] type to handle the check whether the provided `message` is a [`string`][js-string] type or whether it's an object that contains required [`problem`][error-property-problem] and [`fix`][error-property-fix] properties or whether it's a [`string`][js-string] type. |
+
+**Returns:**
+
+The **return value** is an instance of an [`ValidationError`](#validationerror).
+
+**Usage:**
+
+```typescript
+// Example usage with a callback.
+import { ValidationError } from '@angular-package/error';
+
+// Initialize an instance.
+const validationError = new ValidationError();
+
+// Define a fix.
+const fix = 'There is no solution to the described problem.';
+
+// Define a problem.
+const problem = 'The problem has no solution.';
+
+// Define a template.
+const template = 'PROBLEM: [problem], FIX: [fix]';
+
+// Set the message and handle the check of it with a callback.
+validationError.setMessage({ fix, problem }, (result, payload) => {
+  // Returns `false` then `true`.
+  result;
+  /*
+    Returns {
+      "fix": "There is no solution to the described problem.",
+      "problem": "The problem has no solution.",
+      "template": "PROBLEM: [problem] FIX: [fix]"
+    }
+  */
+  payload;
+  return result;
+});
+/*
+  Returns
+  PROBLEM: The problem has no solution. FIX: There is no solution to the described problem.
+*/
+console.log(validationError.message);
+```
+
+<br>
+
+#### `ValidationError.prototype.setProblem()`
+
+![new]
+
+Sets description [`problem`][error-property-problem] of a validation error.
+
+```typescript
+public setProblem(
+  problem: string,
+  callback: ResultCallback<CallbackPayload> = this.#callback.getCallback(
+    'setProblem'
+  )
+): this {
+  this.#problem = guard.string(problem, callback) ? problem : this.#problem;
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                                   | Description |
+| :------------------------------------------- | :---------- |
+| `fix: string`                                | A possible solution to the described [`problem`][error-property-problem] guarded by a [`string`][js-string] type. |
+| `callback?: ResultCallback<CallbackPayload>` | An optional callback function of [`ResultCallback`][package-callback-resultcallback] type to handle the check whether the provided `fix` is a [`string`][js-string]. |
+
+**Returns:**
+
+The **return value** is an instance of an [`ValidationError`](#validationerror).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { ValidationError } from '@angular-package/error';
+
+// Initialize an instance.
+const validationError = new ValidationError();
+
+// Define a problem.
+const problem = 'The problem has no solution.';
+
+// Returns 'The problem has no solution.'
+validationError.setProblem(problem).problem;
+```
+
+```typescript
+// Example usage with a callback.
+import { ValidationError } from '@angular-package/error';
+
+// Initialize an instance.
+const validationError = new ValidationError();
+
+// Define a problem.
+const problem = 'The problem has no solution.';
+
+// Set the problem and handle the check of it with a callback.
+validationError.setProblem(problem, (result, payload) => {
+  // Returns `true`.
+  result;
+  // Returns 'The problem has no solution.'
+  payload;
+  return result;
+});
+```
+
+<br>
+
+#### `ValidationError.prototype.setTemplate()`
+
+![new]
+
+Sets the [`template`][error-property-template] of validation error message.
+
+```typescript
+public setTemplate(
+  template: string,
+  callback: ResultCallback<CallbackPayload> = this.#callback.getCallback(
+    'setTemplate'
+  )
+): this {
+  this.#tpl = ValidationError.#guardTemplate(template, callback)
+    ? template
+    : this.#tpl;
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                                   | Description |
+| :------------------------------------------- | :---------- |
+| `template: string`                           | A message [`template`][error-property-template] guarded by a [`string`][js-string] type with replaceable `[problem]` and `[fix]` words. |
+| `callback?: ResultCallback<CallbackPayload>` | An optional callback function of [`ResultCallback`][package-callback-resultcallback] type to handle the check whether the provided `template` is a [`string`][js-string] that contains `[fix]` and `[problem]` words. |
+
+**Returns:**
+
+The **return value** is an instance of an [`ValidationError`](#validationerror).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { ValidationError } from '@angular-package/error';
+
+// Initialize an instance.
+const validationError = new ValidationError();
+
+// Define a template.
+const template = 'PROBLEM: [problem], FIX: [fix]';
+
+// Set the template.
+validationError.setTemplate(template);
+
+// Returns 'PROBLEM: [problem], FIX: [fix]'
+validationError.template;
+```
+
+```typescript
+// Example usage with a callback.
+import { ValidationError } from '@angular-package/error';
+
+// Initialize an instance.
+const validationError = new ValidationError();
+
+// Define a template.
+const template = 'PROBLEM: [problem], FIX: [fix]';
+
+// Set the template and handle the check of it with a callback.
+validationError.setTemplate(template, (result, payload) => {
+  // Returns `true`.
+  result;
+  // Returns 'PROBLEM: [problem], FIX: [fix]'
+  payload;
+  return result;
+});
+```
+
+<br>
+
+#### `ValidationError.prototype.throw()`
+
+![new]
+
+Throws an error of [`ValidationError`](#validationerror) with the message built from the stored [`fix`][error-property-fix], [`problem`][error-property-problem] and [`template`][error-property-template] or optionally from the provided `message`.
+
+```typescript
+public throw(message?: string | ErrorMessage): void {
+  if (is.defined(message)) {
+    this.setMessage(message);
+  } else {
+    this.updateMessage();
+  }
+  throw this;
+}
+```
+
+**Parameters:**
+
+| Name: type                         | Description |
+| :--------------------------------- | :---------- |
+| `message?: string \| ErrorMessage` | An optional object of an [`ErrorMessage`](#errormessage) interface to build the message of a [`string`][js-string] type. The value is checked against the proper `object`. |
+
+**Returns:**
+
+The **return value** is an instance of an [`ValidationError`](#validationerror).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { ValidationError } from '@angular-package/error';
+
+// Define a fix.
+const fix = 'There is no solution to the described problem.';
+
+// Define a problem.
+const problem = 'The problem has no solution.';
+
+// Define a template.
+const template = 'PROBLEM: [problem] FIX: [fix]';
+
+// Initialize an instance.
+const validationError = new ValidationError({ fix, problem, template });
+
+// Throw an error.
+validationError.throw();
 ```
 
 <br>
@@ -370,17 +801,23 @@ const validationError = new ValidationError({ fix, problem });
 The shape of an [`object`][js-object] for an [`error`][js-error] message that contains a possible solution to the described problem.
 
 ```typescript
-interface ErrorMessage {
-  /**
-   * Possible solution to the described problem of a `string` type.
-   */
+export interface ErrorMessage {
   fix: string;
-  /**
-   * Error problem of a `string` type.
-   */
   problem: string;
+  template?: string;
 }
 ```
+
+**Properties:**
+
+**`fix: string`**  
+Possible solution to the described problem of a [`string`][js-string] type.
+
+**`problem: string`**  
+Description of validation problem of a [`string`][js-string] type.
+
+**`template?: string`**  
+An optional message template of a [`string`][js-string] type.
 
 <br>
 
@@ -564,6 +1001,8 @@ MIT © angular-package ([license][error-license])
 
   <!-- GitHub -->
   [callback-github-readme]: https://github.com/angular-package/callback#readme
+
+  [package-callback-resultcallback]: https://github.com/angular-package/callback#resultcallback
 
 <!-- Package: change-detection -->
   <!-- npm -->

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Manages an [`Error`][js-error] of validation.
 
 ![update]
 
-[2.0.0]: Uses static private property `#template` and guards the value with private static method `#guardTemplate()` to be `string` type that contains `[fix]` and `[problem]` words.
+**`2.0.0`:** Uses static private property `#template` and guards the value with private static method `#guardTemplate()` to be `string` type that contains `[fix]` and `[problem]` words.
 
 A template of the error message guarded by [`string`][js-string] type with the replaceable `[problem]` and `[fix]` words. By default, it's set to `Problem: [problem] => Fix: [fix]`. It can be set directly or by the [`setTemplate()`][error-method-settemplate] and [`setMessage()`][error-method-setmessage] method. The value is being checked against the existence of `[problem]` and `[fix]` words.
 
@@ -220,7 +220,7 @@ static set template(value: string) {
 
 ![update]
 
-[2.0.0]: Uses static private property `#fix` and guards the value to be a [`string`][js-string] type.
+**`2.0.0`:** Uses static private property `#fix` and guards the value to be a [`string`][js-string] type.
 
 A possible solution to the described [`problem`][error-property-problem] of validation that is guarded by a [`string`][js-string] type. By default, it's an empty [`string`][js-string]. It can be set directly or by the [`setFix()`][error-method-setfix] and [`setMessage()`][error-method-setmessage] method.
 
@@ -239,7 +239,7 @@ public set fix(value: string) {
 
 ![update]
 
-[2.0.0]: Uses inherited from `Error` property and guards the value to be a [`string`][js-string] type.
+**`2.0.0`:** Uses inherited from `Error` property and guards the value to be a [`string`][js-string] type.
 
 A validation error message guarded by a [`string`][js-string] type that can be build from the [`problem`][error-property-problem] and [`fix`][error-property-fix] of [`ValidationError`](#validationerror) on the [`template`][error-property-template]. It can be set directly or by the [`throw()`][error-method-throw] and [`setMessage()`][error-method-setmessage] method.
 
@@ -289,7 +289,7 @@ public set problem(value: string) {
 
 ![update]
 
-[2.0.0]: Adds template to the provided `message` instead of separate parameter and guards it with a static `#guardMessage()` method.
+**`2.0.0`:** Adds template to the provided `message` instead of separate parameter and guards it with a static `#guardMessage()` method.
 
 Defines the validation error message of a [`string`][js-string] type from the provided `message` of the [`ErrorMessage`](#errormessage) interface.
 
@@ -409,7 +409,7 @@ const errorMessage = ValidationError.defineMessage(
 
 ![update]
 
-[2.0.0]: Adds template to the provided `message` instead of separate parameter and uses a new method [`setMessage()`][error-method-setmessage] to set message. Handle the callback for all instance methods with the callback parameter.
+**`2.0.0`:** Adds template to the provided `message` instead of separate parameter and uses a new method [`setMessage()`][error-method-setmessage] to set message. Handle the callback for all instance methods with the callback parameter.
 
 Creates a new instance with the message. If the provided `message` is an [`object`][js-object], then its properties are assigned to the instance.
 
@@ -975,7 +975,7 @@ addPerson({
 
 ![update]
 
-[2.0.0]: Adds an optional `template` property.
+`2.0.0`: Adds an optional `template` property.
 
 The shape of an [`object`][js-object] for an [`error`][js-error] message that contains a possible solution to the described problem.
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Manages an [`Error`][js-error] of validation.
 
 ![update]
 
-A template of the error message guarded by [`string`][js-string] type with the replaceable `[problem]` and `[fix]` words. By default, it's set to `Problem: [problem] => Fix: [fix]`.
+A template of the error message guarded by [`string`][js-string] type with the replaceable `[problem]` and `[fix]` words. By default, it's set to `Problem: [problem] => Fix: [fix]`. It can be set directly or by the [`setTemplate()`][error-method-settemplate] and [`setMessage()`][error-method-setmessage] method.
 
 ```typescript
 static get template(): string {
@@ -215,7 +215,7 @@ static set template(value: string) {
 
 ![update]
 
-A possible solution to the described [`problem`][error-property-problem] of validation that is guarded by a [`string`][js-string] type. By default, it's an empty [`string`][js-string].
+A possible solution to the described [`problem`][error-property-problem] of validation that is guarded by a [`string`][js-string] type. By default, it's an empty [`string`][js-string]. It can be set directly or by the [`setFix()`][error-method-setfix] and [`setMessage()`][error-method-setmessage] method.
 
 ```typescript
 public get fix(): string {
@@ -230,7 +230,9 @@ public set fix(value: string) {
 
 #### `ValidationError.prototype.message`
 
-A validation error message guarded by a [`string`][js-string] type that can be build from the [`problem`][error-property-problem] and [`fix`][error-property-fix] of [`ValidationError`](#validationerror) on the [`template`][error-property-template].
+![update]
+
+A validation error message guarded by a [`string`][js-string] type that can be build from the [`problem`][error-property-problem] and [`fix`][error-property-fix] of [`ValidationError`](#validationerror) on the [`template`][error-property-template]. It can be set directly or by the [`throw()`][error-method-throw] and [`setMessage()`][error-method-setmessage] method.
 
 ```typescript
 public set message(value: string) {
@@ -245,8 +247,6 @@ public get message(): string {
 
 #### `ValidationError.prototype.name`
 
-![update]
-
 Error name of a [`string`][js-string] type that is being thrown. By default, it's ['ValidationError'](#validationerror).
 
 ```typescript
@@ -259,7 +259,7 @@ public name = ValidationError.name;
 
 ![update]
 
-Description of a validation [`problem`][error-property-problem] guarded by a [`string`][js-string] type. By default, it's an empty [`string`][js-string].
+Description of a validation [`problem`][error-property-problem] guarded by a [`string`][js-string] type. By default, it's an empty [`string`][js-string]. It can be set directly or by the [`setProblem()`][error-method-setproblem] and [`setMessage()`][error-method-setmessage] method.
 
 ```typescript
 public get problem(): string {
@@ -283,6 +283,7 @@ public set problem(value: string) {
 Defines the validation error message of a [`string`][js-string] type from the provided `message` of the [`ErrorMessage`](#errormessage) interface.
 
 ```typescript
+// Syntax.
 public static defineMessage(
   message: ErrorMessage,
   callback?: ResultCallback<CallbackPayload & ErrorMessage>
@@ -401,6 +402,7 @@ const errorMessage = ValidationError.defineMessage(
 Creates a new instance with the message. If the provided `message` is an [`object`][js-object], then its properties are assigned to the instance.
 
 ```typescript
+// Syntax.
 constructor(
   message: string | ErrorMessage = '',
   callback?: (callback: Callback<AllowedCallback>) => void

--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ Creates a new instance with the message. If the provided `message` is an [`objec
 // Syntax.
 constructor(
   message: string | ErrorMessage = '',
-  callback?: (callback: Callback<AllowedCallback>) => void
+  callback?: (callback: Callback<VEAllowedCallback>) => void
 ) {
   super();
 
@@ -423,10 +423,10 @@ constructor(
 
 **Parameters:**
 
-| Name: type                        | Description |
-| :-------------------------------- | :---------- |
-| `message: string \| ErrorMessage` | The message of a [`string`][js-string] type or of an [`ErrorMessage`](#errormessage) interface that is used to throw with an [`Error`][js-error]. |
-| `callback?: (callback: Callback<AllowedCallback>) => void` | An optional function to handle the internal instance of [`Callback`][callback-github-readme]. |
+| Name: type                                                   | Description |
+| :----------------------------------------------------------- | :---------- |
+| `message: string \| ErrorMessage`                            | The message of a [`string`][js-string] type or of an [`ErrorMessage`](#errormessage) interface that is used to throw with an [`Error`][js-error]. |
+| `callback?: (callback: Callback<VEAllowedCallback>) => void` | An optional function to handle the internal instance of [`Callback`][callback-github-readme]. |
 
 **Returns:**
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Manages an [`Error`][js-error].
 * [Api](#api)
 * [`ValidationError`](#validationerror)
 * [Interface](#interface)
+* [Type](#type)
 * [Experimental](#experimental)
 * [Changelog](#changelog)
 * [Git](#git)
@@ -168,19 +169,21 @@ Manages an [`Error`][js-error] of validation.
 
 **Instance methods:**
 
-| ValidationError.prototype.                  | Description |
-| :------------------------------------------ | :---------- |
-| [`setFix()`][error-method-setfix]           | Sets the fix a possible solution to the described [`problem`][error-property-problem]. |
-| [`setMessage()`][error-method-setmessage]   | Sets the validation error message of a [`string`][js-string] type from the provided `message` of the [`ErrorMessage`](#errormessage) interface. |
-| [`setProblem()`][error-method-setproblem]   | Sets description problem of a [`ValidationError`](#validationerror). |
-| [`setTemplate()`][error-method-settemplate] | Sets the template of validation error message. |
-| [`throw()`][error-method-throw]             | Throws an error of [`ValidationError`](#validationerror) with actual settings. |
+| ValidationError.prototype.                      | Description |
+| :---------------------------------------------- | :---------- |
+| [`setFix()`][error-method-setfix]               | Sets the fix a possible solution to the described [`problem`][error-property-problem]. |
+| [`setMessage()`][error-method-setmessage]       | Sets the validation error message of a [`string`][js-string] type from the provided `message` of the [`ErrorMessage`](#errormessage) interface. |
+| [`setProblem()`][error-method-setproblem]       | Sets description problem of a [`ValidationError`](#validationerror). |
+| [`setTemplate()`][error-method-settemplate]     | Sets the template of validation error message. |
+| [`throw()`][error-method-throw]                 | Throws an error of [`ValidationError`](#validationerror) with actual settings. |
+| [`updateMessage()`][error-method-updatemessage] | Updates the message with a stored [`fix`][error-property-fix], [`problem`][error-property-problem], and [`template`][error-property-template]. |
 
 [error-method-setfix]: #validationerrorprototypesetfix
 [error-method-setmessage]: #validationerrorprototypesetmessage
 [error-method-setproblem]: #validationerrorprototypesetproblem
 [error-method-settemplate]: #validationerrorprototypesettemplate
 [error-method-throw]: #validationerrorprototypethrow
+[error-method-updatemessage]: #validationerrorprototypeupdatemessage
 
 <br>
 
@@ -301,7 +304,6 @@ public static defineMessage(
 | Name: type                  | Description |
 | :-------------------------- | :---------- |
 | `message: ErrorMessage`     | An [`object`][js-object] of the [`ErrorMessage`](#errormessage) interface to build a message of a [`string`][js-string] type. The value is checked against the proper [`object`][js-object] |
-| `template: string`          | A message template of a [`string`][js-string] type with replaceable `[problem]` and `[fix]` from the given `message`. The value is checked against a [`string`][js-string]. By default, it's set to `Problem: [problem] => Fix: [fix]` |
 | `callback?: ResultCallback` | An optional callback function of [`ResultCallback`][package-callback-resultcallback] type to handle the check whether the provided message contains required `problem` and `fix` properties |
 
 **Returns:**
@@ -444,7 +446,57 @@ const validationError = new ValidationError({ fix, problem });
 
 ```typescript
 // Example usage with callback.
+import { ValidationError } from '@angular-package/error';
 
+// Define a fix.
+const fix = 'There is no solution to the described problem.';
+
+// Define a problem.
+const problem = 'The problem has no solution.';
+
+// Define a template.
+const template = 'PROBLEM: [problem] FIX: [fix]';
+
+// Initialize an instance.
+const validationError = new ValidationError(
+  { fix, problem, template },
+  (callback) => {
+    callback
+      /*
+      Console: false,
+      {
+        "fix": "There is no solution to the described problem.",
+        "problem": "The problem has no solution.",
+        "template": "PROBLEM: [problem] FIX: [fix]"
+      }
+
+      Console: true,
+      {
+        "fix": "There is no solution to the described problem.",
+        "problem": "The problem has no solution.",
+        "template": "PROBLEM: [problem] FIX: [fix]"
+      }
+    */
+      .setResultCallback('setFix', (result, payload) =>
+        console.log(`setFix`, result, payload);
+      )
+
+      // Console: 'setFix true There is no solution to the described problem.'
+      .setResultCallback('setMessage', (result, payload) =>
+        console.log(`setMessage`, result, payload);
+      )
+
+      // Console: 'setProblem true The problem has no solution.'
+      .setResultCallback('setProblem', (result, payload) =>
+        console.log(`setProblem`, result, payload);
+      )
+
+      // Console: 'setTemplate true PROBLEM: [problem] FIX: [fix]'
+      .setResultCallback('setTemplate', (result, payload) =>
+        console.log(`setTemplate`, result, payload);
+      );
+  }
+);
 ```
 
 <br>
@@ -479,7 +531,7 @@ public setFix(
 | Name: type                                   | Description |
 | :------------------------------------------- | :---------- |
 | `fix: string`                                | A possible solution to the described problem guarded by a [`string`][js-string] type. |
-| `callback?: ResultCallback<CallbackPayload>` | An optional callback function of [`ResultCallback`][package-callback-resultcallback] type to handle the check whether the provided [`fix`][error-property-fix] is a [`string`][js-string]. |
+| `callback?: ResultCallback<CallbackPayload>` | An optional callback function of [`ResultCallback`][package-callback-resultcallback] type to handle the check whether the provided [`fix`][error-property-fix] is a [`string`][js-string]. It can be initially set by callback |
 
 **Returns:**
 
@@ -796,6 +848,68 @@ validationError.throw();
 
 <br>
 
+#### `ValidationError.prototype.updateMessage()`
+
+![new]
+
+Updates the message with a stored [`fix`][error-property-fix], [`problem`][error-property-problem], and [`template`][error-property-template].
+
+```typescript
+public updateMessage(): void {
+  this.message = ValidationError.defineMessage({
+    fix: this.#fix,
+    problem: this.#problem,
+    template: this.#tpl,
+  });
+}
+```
+
+**Returns:**
+
+The **return value** is an instance of an [`ValidationError`](#validationerror).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { ValidationError } from '@angular-package/error';
+
+// Define a fix.
+const fix = 'There is no solution to the described problem.';
+
+// Define a problem.
+const problem = 'The problem has no solution.';
+
+// Define a template.
+const template = 'PROBLEM: [problem] FIX: [fix]';
+
+// Initialize an instance.
+const validationError = new ValidationError();
+
+// Sets defined above fix, problem, and template.
+validationError.setProblem(problem).setFix(fix).setTemplate(template);
+
+// Returns empty string.
+validationError.message;
+
+// Update the message with actual settings.
+validationError.updateMessage();
+
+/*
+  Returns
+  PROBLEM: The problem has no solution. FIX: There is no solution to the described problem.
+*/
+validationError.message;
+
+// Throw.
+validationError.throw();
+
+// or throw
+throw validationError;
+```
+
+<br>
+
 ### Complete usage of `ValidationError`
 
 ```typescript
@@ -805,8 +919,6 @@ validationError.throw();
 <br>
 
 ## Interface
-
-### Common
 
 #### `ErrorMessage`
 
@@ -830,6 +942,18 @@ Description of validation problem of a [`string`][js-string] type.
 
 **`template?: string`**  
 An optional message template of a [`string`][js-string] type.
+
+<br>
+
+## Interface
+
+#### `VEAllowedCallback`
+
+Allowed callback function names available for the [`ValidationError`](#validationerror).
+
+```typescript
+type VEAllowedCallback = 'setFix' | 'setMessage' | 'setProblem' | 'setTemplate';
+```
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Manages an [`Error`][js-error] of validation.
 
 ![update]
 
-A template of the error message guarded by [`string`][js-string] type with the replaceable `[problem]` and `[fix]` words. By default, it's set to `Problem: [problem] => Fix: [fix]`. It can be set directly or by the [`setTemplate()`][error-method-settemplate] and [`setMessage()`][error-method-setmessage] method.
+A template of the error message guarded by [`string`][js-string] type with the replaceable `[problem]` and `[fix]` words. By default, it's set to `Problem: [problem] => Fix: [fix]`. It can be set directly or by the [`setTemplate()`][error-method-settemplate] and [`setMessage()`][error-method-setmessage] method. The value is being checked against the existence of `[problem]` and `[fix]` words.
 
 ```typescript
 static get template(): string {
@@ -910,10 +910,51 @@ throw validationError;
 
 <br>
 
-### Complete usage of `ValidationError`
+### Another example usage of `ValidationError`
 
 ```typescript
-//
+// Example usage.
+import { ValidationError } from '@angular-package/error';
+
+// Declare shape of the person.
+interface Person {
+  firstName: string;
+  lastName: string;
+}
+
+// Initialize an instance.
+const validationErrorOfPerson = new ValidationError();
+
+// Define a fix.
+const fix = 'Please, provide only alphabetical characters.';
+
+// Create an object.
+const personError = {
+  firstName: validationErrorOfPerson.setMessage({
+    problem: 'Provided the first name cannot include special characters.',
+    fix
+  }),
+  lastName: validationErrorOfPerson.setMessage({
+    problem: 'Provided the last name cannot include special characters.',
+    fix
+  })
+};
+
+
+const addPerson = (person: Person) => {
+  if (person.firstName.includes('#')) {
+    personError.firstName.throw();
+  }
+  if (person.firstName.includes('#')) {
+    personError.lastName.throw();
+  }
+};
+
+addPerson({
+  firstName: '#',
+  lastName: '#'
+});
+
 ```
 
 <br>

--- a/README.md
+++ b/README.md
@@ -975,7 +975,7 @@ addPerson({
 
 ![update]
 
-`2.0.0`: Adds an optional `template` property.
+**`2.0.0`:** Adds an optional `template` property.
 
 The shape of an [`object`][js-object] for an [`error`][js-error] message that contains a possible solution to the described problem.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,14 +15,14 @@
         "@angular-package/testing": "^1.1.0"
       },
       "peerDependencies": {
-        "@angular-package/callback": "^1.0.0",
+        "@angular-package/callback": "^1.0.1",
         "@angular-package/type": "^4.2.0"
       }
     },
     "node_modules/@angular-package/callback": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@angular-package/callback/-/callback-1.0.0.tgz",
-      "integrity": "sha512-e3ZXFxNNtSqGE4AfY/7T+dbSznHGV/NIPE+NpNlbfWh3io2694MzxWgORBm2/WZWbrSLfzTfWmL5cRAfzIPvww==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@angular-package/callback/-/callback-1.0.1.tgz",
+      "integrity": "sha512-WIsZ+fEO1BUlBDTJYAstd2u+MA+07Ky+mHz51yChXFdsBW8MKk5V4PD26VYjBak98AXpA7GDOvpj/6iJAlUqOA==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.2.0"
@@ -206,9 +206,9 @@
   },
   "dependencies": {
     "@angular-package/callback": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@angular-package/callback/-/callback-1.0.0.tgz",
-      "integrity": "sha512-e3ZXFxNNtSqGE4AfY/7T+dbSznHGV/NIPE+NpNlbfWh3io2694MzxWgORBm2/WZWbrSLfzTfWmL5cRAfzIPvww==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@angular-package/callback/-/callback-1.0.1.tgz",
+      "integrity": "sha512-WIsZ+fEO1BUlBDTJYAstd2u+MA+07Ky+mHz51yChXFdsBW8MKk5V4PD26VYjBak98AXpA7GDOvpj/6iJAlUqOA==",
       "peer": true,
       "requires": {
         "tslib": "^2.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
-  "name": "error",
+  "name": "@angular-package/error",
   "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "@angular-package/error",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.2.0"
@@ -13,11 +15,34 @@
         "@angular-package/testing": "^1.1.0"
       },
       "peerDependencies": {
-        "@angular-package/type": "^4.2.0",
-        "@angular/common": "^12.1.1",
-        "@angular/core": "^12.1.1"
+        "@angular-package/callback": "^1.0.0",
+        "@angular-package/type": "^4.2.0"
+      }
+    },
+    "node_modules/@angular-package/callback": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@angular-package/callback/-/callback-1.0.0.tgz",
+      "integrity": "sha512-e3ZXFxNNtSqGE4AfY/7T+dbSznHGV/NIPE+NpNlbfWh3io2694MzxWgORBm2/WZWbrSLfzTfWmL5cRAfzIPvww==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.2.0"
       },
-      "version": "1.0.3"
+      "peerDependencies": {
+        "@angular-package/error": "^1.0.1",
+        "@angular-package/type": "^4.2.0"
+      }
+    },
+    "node_modules/@angular-package/error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@angular-package/error/-/error-1.0.3.tgz",
+      "integrity": "sha512-u5aYxX8ifnBdXrVtsDPcvlvQlLmzXo4BJkYup4jELlCdfvyzo5e6ze+dDekCzhBuSbHCcEgJi/6zYVufjXK4qQ==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "peerDependencies": {
+        "@angular-package/type": "^4.2.0"
+      }
     },
     "node_modules/@angular-package/testing": {
       "version": "1.1.0",
@@ -39,38 +64,6 @@
       "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@angular/common": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-12.1.4.tgz",
-      "integrity": "sha512-cyh2m5veGgWRFsrmPnwB/Ised90bFNZAjZepvW8WXrpEUa/tmi1yWU9+8ayRG7ztE08lyXncJSSut2Ss2PEhTA==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": "^12.14.1 || >=14.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "12.1.4",
-        "rxjs": "^6.5.3"
-      }
-    },
-    "node_modules/@angular/core": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-12.1.4.tgz",
-      "integrity": "sha512-dG7KtW0l3jI8lapmenSu1wV/d3VOphAjDxVqWOrwh+kI0da7677cEg0Ms5YIF8Nf/++WleyNxk6AIHbDIig+Sw==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": "^12.14.1 || >=14.0.0"
-      },
-      "peerDependencies": {
-        "rxjs": "^6.5.3",
-        "zone.js": "~0.11.4"
       }
     },
     "node_modules/balanced-match": {
@@ -198,24 +191,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "peer": true
-    },
     "node_modules/tslib": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
@@ -227,18 +202,27 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true,
       "peer": true
-    },
-    "node_modules/zone.js": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.4.tgz",
-      "integrity": "sha512-DDh2Ab+A/B+9mJyajPjHFPWfYU1H+pdun4wnnk0OcQTNjem1XQSZ2CDW+rfZEUDjv5M19SBqAkjZi0x5wuB5Qw==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.0.0"
-      }
     }
   },
   "dependencies": {
+    "@angular-package/callback": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@angular-package/callback/-/callback-1.0.0.tgz",
+      "integrity": "sha512-e3ZXFxNNtSqGE4AfY/7T+dbSznHGV/NIPE+NpNlbfWh3io2694MzxWgORBm2/WZWbrSLfzTfWmL5cRAfzIPvww==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.2.0"
+      }
+    },
+    "@angular-package/error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@angular-package/error/-/error-1.0.3.tgz",
+      "integrity": "sha512-u5aYxX8ifnBdXrVtsDPcvlvQlLmzXo4BJkYup4jELlCdfvyzo5e6ze+dDekCzhBuSbHCcEgJi/6zYVufjXK4qQ==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.2.0"
+      }
+    },
     "@angular-package/testing": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@angular-package/testing/-/testing-1.1.0.tgz",
@@ -255,24 +239,6 @@
       "peer": true,
       "requires": {
         "tslib": "^2.1.0"
-      }
-    },
-    "@angular/common": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-12.1.4.tgz",
-      "integrity": "sha512-cyh2m5veGgWRFsrmPnwB/Ised90bFNZAjZepvW8WXrpEUa/tmi1yWU9+8ayRG7ztE08lyXncJSSut2Ss2PEhTA==",
-      "peer": true,
-      "requires": {
-        "tslib": "^2.2.0"
-      }
-    },
-    "@angular/core": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-12.1.4.tgz",
-      "integrity": "sha512-dG7KtW0l3jI8lapmenSu1wV/d3VOphAjDxVqWOrwh+kI0da7677cEg0Ms5YIF8Nf/++WleyNxk6AIHbDIig+Sw==",
-      "peer": true,
-      "requires": {
-        "tslib": "^2.2.0"
       }
     },
     "balanced-match": {
@@ -385,23 +351,6 @@
       "dev": true,
       "peer": true
     },
-    "rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "peer": true,
-      "requires": {
-        "tslib": "^1.9.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "peer": true
-        }
-      }
-    },
     "tslib": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
@@ -413,15 +362,6 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true,
       "peer": true
-    },
-    "zone.js": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.4.tgz",
-      "integrity": "sha512-DDh2Ab+A/B+9mJyajPjHFPWfYU1H+pdun4wnnk0OcQTNjem1XQSZ2CDW+rfZEUDjv5M19SBqAkjZi0x5wuB5Qw==",
-      "peer": true,
-      "requires": {
-        "tslib": "^2.0.0"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Angular Package <angular-package@wvvw.dev> (https://wvvw.dev)",
   "homepage": "https://github.com/angular-package/error#readme",
   "peerDependencies": {
+    "@angular-package/callback": "^1.0.0",
     "@angular-package/type": "^4.2.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@angular-package/error",
   "version": "1.0.3",
-  "description": "Manages the callback function.",
+  "description": "Manages an error.",
   "author": "Angular Package <angular-package@wvvw.dev> (https://wvvw.dev)",
   "homepage": "https://github.com/angular-package/error#readme",
   "peerDependencies": {
-    "@angular-package/callback": "^1.0.0",
+    "@angular-package/callback": "^1.0.1",
     "@angular-package/type": "^4.2.0"
   },
   "dependencies": {

--- a/src/interface/error-message.interface.ts
+++ b/src/interface/error-message.interface.ts
@@ -1,13 +1,22 @@
 /**
  * The shape of an `object` for the error message that contains a possible solution to the described problem.
+ * @param fix A possible solution to the described problem of a `string` type.
+ * @param problem Description of validation problem of a string type.
+ * @param template An optional message template of a `string` type.
  */
 export interface ErrorMessage {
   /**
-   * Possible solution to the described problem of a `string` type.
+   * A possible solution to the described problem of a `string` type.
    */
   fix: string;
+
   /**
-   * Error problem of a `string` type.
+   * Description of validation problem of a `string` type.
    */
   problem: string;
+
+  /**
+   * An optional message template of a `string` type.
+   */
+  template?: string;
 }

--- a/src/lib/validation-error.class.ts
+++ b/src/lib/validation-error.class.ts
@@ -1,74 +1,314 @@
-// Object.
-import { is, ResultCallback } from '@angular-package/type';
+// @angular-package/type.
+import { is, guard } from '@angular-package/type';
+
+// @angular-package/callback.
+import {
+  Callback,
+  CallbackPayload,
+  ResultCallback,
+} from '@angular-package/callback';
+
 // Interface.
 import { ErrorMessage } from '../interface/error-message.interface';
+
+// Type.
+import { VEAllowedCallback } from '../type/allowed-callback.type';
+
 /**
- * Manages an `Error` of the validation.
+ * Manages an `Error` of validation.
  */
 export class ValidationError extends Error {
+  /* #region static private properties */
   /**
-   * Template of the error message with the replaceable [problem] and [fix].
+   * A static, privately stored template of the error message.
+   */
+  static #template = `Problem: [problem] => Fix: [fix]`;
+  /* #endregion static private properties */
+
+  //#region instance private properties.
+  /**
+   * An instance of `Callback` with specified allowed names of callback functions for the `ValidationError`.
+   */
+  #callback = new Callback('setFix', 'setMessage', 'setProblem', 'setTemplate');
+
+  /**
+   * A privately stored possible solution to the described problem of a `string` type.
+   * By default, it's an empty `string`.
+   */
+  #fix = '';
+
+  /**
+   * A privately stored validation problem of a `string` type.
+   * By default, it's an empty `string`.
+   */
+  #problem = '';
+
+  /**
+   * A string-type privately stored template of the error message that contains replaceable `[fix]` and `[problem]` words.
+   */
+  #tpl = ValidationError.template;
+  //#endregion instance private properties.
+
+  /**
+   * A template of the error message guarded by a `string` type with the replaceable `[problem]` and `[fix]` words.
+   * The value is being checked against the existence of `[problem]` and `[fix]` words.
    * By default, it's set to `Problem: [problem] => Fix: [fix]`.
    */
-  static template = `Problem: [problem] => Fix: [fix]`;
+  static get template(): string {
+    return ValidationError.#template;
+  }
+  static set template(value: string) {
+    ValidationError.#template = ValidationError.#guardTemplate(value)
+      ? value
+      : ValidationError.#template;
+  }
 
+  //#region instance public properties.
   /**
-   * A possible solution to the described problem of a `string` type. By default, it's an empty `string`.
+   * A possible solution to the described `problem` of validation that is guarded by a `string` type.
+   * By default, it's an empty `string`.
    */
-  public fix = '';
+  public get fix(): string {
+    return this.#fix;
+  }
+  public set fix(value: string) {
+    this.#fix = guard.string(value) ? value : this.#fix;
+  }
 
   /**
-   * Error name of a `string` type that is being thrown. By default, it's `ValidationError`.
+   * A validation error message guarded by a `string` type that can be built with the `problem` and `fix` of `ValidationError` by the
+   * `throw()` and `setMessage()` method.
+   */
+  public set message(value: string) {
+    super.message = guard.string(value) ? value : super.message;
+  }
+  public get message(): string {
+    return super.message;
+  }
+
+  /**
+   * Error name of a `string` type that is being thrown.
+   * By default, it's `ValidationError`.
    */
   public name = ValidationError.name;
 
   /**
-   * The validation problem of a `string` type. By default, it's an empty `string`.
+   * Description of a validation problem guarded by a `string` type.
+   * By default, it's an empty `string`.
    */
-  public problem = '';
+  public get problem(): string {
+    return this.#problem;
+  }
+  public set problem(value: string) {
+    this.#problem = guard.string(value) ? value : this.#problem;
+  }
+  //#endregion instance public properties.
 
+  //#region static public methods
   /**
    * Defines the validation error message of a `string` type from the provided `message` of the `ErrorMessage` interface.
    * @param message An object of an `ErrorMessage` interface to build the message of a `string` type. The value is checked against
    * the proper `object`.
-   * @param template A message template of a `string` type with replaceable `[problem]` and `[fix]` from the given `message`. The value is
-   * checked against a `string`. By default, it's set to `Problem: [problem] => Fix: [fix]`.
    * @param callback An optional callback function of `ResultCallback` type to handle the check whether the provided message contains
    * required `problem` and `fix` properties.
    * @returns The return value is a message of a `string` type created from the provided `message` of `ErrorMessage` interface or it's an
    * empty `string` if the provided message object isn't proper.
    * @angularpackage
    */
-  static defineMessage(
+  public static defineMessage(
     message: ErrorMessage,
-    template: string = ValidationError.template,
-    callback?: ResultCallback
+    callback?: ResultCallback<CallbackPayload & ErrorMessage>
   ): string {
-    if (is.objectKey(message, ['fix', 'problem'], callback)) {
-      if (is.string(template)) {
-        return template
+    return ValidationError.#guardMessage(message, callback)
+      ? (message.template || ValidationError.template)
           .replace(`[fix]`, message.fix)
-          .replace(`[problem]`, message.problem);
-      }
-    }
-    return '';
+          .replace(`[problem]`, message.problem)
+      : '';
   }
+  //#endregion static public methods
+
+  //#region private static methods.
+  /**
+   * Guards the provided message to be of `ErrorMessage` shape.
+   * @param message An object of the `ErrorMessage` interface to build the message of a `string` type. The value is checked against
+   * the proper `object`.
+   * @param callback An optional callback function of `ResultCallback` type to handle the check whether the provided `message` contains
+   * required `problem` and `fix` properties.
+   * @returns The return value is a `boolean` indicating whether the provided `message` is an object of `ErrorMessage`.
+   * @angularpackage
+   */
+  static #guardMessage<Payload extends object>(
+    message: ErrorMessage,
+    callback?: ResultCallback<Payload & CallbackPayload>
+  ): message is ErrorMessage {
+    return guard.objectKey(message, ['fix', 'problem'], callback)
+      ? is.defined(message.template)
+        ? guard.string(message.problem) &&
+          guard.string(message.fix) &&
+          ValidationError.#guardTemplate(message.template, callback)
+        : guard.string(message.problem) && guard.string(message.fix)
+      : false;
+  }
+
+  /**
+   * Guards the provided `template` to be a `string` type that includes `[fix]` and `[problem]` words.
+   * @param template A string-type value to guard.
+   * @param callback An optional callback function of `ResultCallback` type to handle the check whether the provided message contains
+   * @returns The return value is a `boolean` indicating whether the provided `template` is a `string` that includes `[fix]` and `[problem]`
+   * words.
+   * @angularpackage
+   */
+  static #guardTemplate<Payload extends object>(
+    template: string,
+    callback?: ResultCallback<Payload & CallbackPayload>
+  ): template is string {
+    return guard.string(template, callback)
+      ? template.includes('[fix]') && template.includes('[problem]')
+      : false;
+  }
+  //#endregion private static methods.
 
   /**
    * Creates a new instance with the message. If the provided `message` is an `object`, then its properties are assigned
    * to the instance.
-   * @param message The message of a `string` type or of an `ErrorMessage` interface that is used to throw with an `error`.
+   * @param message The message of a `string` type or of an `ErrorMessage` interface to throw with an `Error`.
+   * @param callback An optional function to handle the internal instance of `Callback`.
    * @angularpackage
    */
-  constructor(message: string | ErrorMessage) {
-    super(
-      is.string(message) ? message : ValidationError.defineMessage(message)
-    );
-    if (is.object(message)) {
-      Object.assign(this, {
-        problem: message.problem,
-        fix: message.fix,
-      });
+  constructor(
+    message: string | ErrorMessage = '',
+    callback?: (callback: Callback<VEAllowedCallback>) => void
+  ) {
+    super();
+
+    // Sets the callback for an instance methods.
+    if (is.function(callback)) {
+      callback(this.#callback);
     }
+
+    // Initializes the message and assigns message properties `fix`, `problem` and optionally `template` to a new instance.
+    this.setMessage(message);
   }
+
+  //#region instance public methods.
+  /**
+   * Sets the fix a possible solution to the described problem.
+   * @param fix A possible solution to the described problem guarded by a `string` type.
+   * @param callback An optional callback function of `ResultCallback` type to handle the check whether the provided `fix` is a `string`.
+   * By default, it uses an internal callback under the `'setFix'` name, which can be initially set by the optional `callback` parameter
+   * that gives access to the internal instance of `Callback`.
+   * @returns The return value is an instance of an `ValidationError`.
+   * @angularpackage
+   */
+  public setFix(
+    fix: string,
+    callback: ResultCallback<CallbackPayload> = this.#callback.getCallback(
+      'setFix'
+    )
+  ): this {
+    if (guard.string(fix, callback)) {
+      this.#fix = fix;
+    }
+    return this;
+  }
+
+  /**
+   * Sets the validation error message of a `string` type from the provided `message` of the `ErrorMessage` interface.
+   * @param message An object of an `ErrorMessage` interface to build the message of a `string` type. The value is checked against
+   * the proper `object`.
+   * @param callback An optional callback function of `ResultCallback` type to handle the check whether the provided message is a string
+   * type or whether it's an object that contains required `problem` and `fix` properties.
+   * By default, it uses an internal callback under the `'setFix'` name, which can be initially set by the optional `callback` parameter
+   * that gives access to the internal instance of `Callback`.
+   * @returns The return value is an instance of an `ValidationError`.
+   * @angularpackage
+   */
+  public setMessage(
+    message: string | ErrorMessage,
+    callback: ResultCallback<
+      CallbackPayload & ErrorMessage
+    > = this.#callback.getCallback('setMessage')
+  ): this {
+    this.message = is.string(message, callback)
+      ? // Sets a message of a string type from the provided message of `string`.
+        message
+      : // Sets a message of a string type from the provided message of `ErrorMessage`.
+        ValidationError.defineMessage(message, callback);
+
+    // Sets `fix`, `problem` and `template` from the provided `message`.
+    if (is.object(message)) {
+      this.setFix(message.fix).setProblem(message.problem);
+      if (is.defined(message.template)) {
+        this.setTemplate(message.template);
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Sets description problem of a validation error.
+   * @param problem Description of a problem of validation error guarded by a `string` type.
+   * @param callback An optional callback function of `ResultCallback` type to handle the check whether the provided `problem` is a
+   * `string`. By default, it uses an internal callback under the `'setProblem'` name, which can be initially set by the optional `callback`
+   * parameter that gives access to the internal instance of `Callback`.
+   * @returns The return value is an instance of an `ValidationError`.
+   * @angularpackage
+   */
+  public setProblem(
+    problem: string,
+    callback: ResultCallback<CallbackPayload> = this.#callback.getCallback(
+      'setProblem'
+    )
+  ): this {
+    this.#problem = guard.string(problem, callback) ? problem : this.#problem;
+    return this;
+  }
+
+  /**
+   * Sets the template of validation error message.
+   * @param template A message template guarded by a `string` type with replaceable `[problem]` and `[fix]` words.
+   * @param callback An optional callback function of `ResultCallback` type to handle the check whether the provided `template` is a
+   * `string` that contains `[fix]` and `[problem]` words. By default, it uses an internal callback under the `'setTemplate'` name, which
+   * can be initially set by the optional `callback` parameter that gives access to the internal instance of `Callback`.
+   * @angularpackage
+   */
+  public setTemplate(
+    template: string,
+    callback: ResultCallback<CallbackPayload> = this.#callback.getCallback(
+      'setTemplate'
+    )
+  ): this {
+    this.#tpl = ValidationError.#guardTemplate(template, callback)
+      ? template
+      : this.#tpl;
+    return this;
+  }
+
+  /**
+   * Throws an error of `ValidationError` with the message built from the stored `fix`, `problem` and `template` or optionally from
+   * the provided `message`.
+   * @param message An optional
+   * @angularpackage
+   */
+  public throw(message?: string | ErrorMessage): void {
+    if (is.defined(message)) {
+      this.setMessage(message);
+    } else {
+      this.updateMessage();
+    }
+    throw this;
+  }
+
+  /**
+   * Updates the message with a stored `fix`, `problem`, and `template`.
+   * @angularpackage
+   */
+  public updateMessage(): void {
+    this.message = ValidationError.defineMessage({
+      fix: this.#fix,
+      problem: this.#problem,
+      template: this.#tpl,
+    });
+  }
+  //#endregion instance public methods.
 }

--- a/src/type/allowed-callback.type.ts
+++ b/src/type/allowed-callback.type.ts
@@ -1,0 +1,4 @@
+/**
+ * Allowed callback function names available for the `ValidationError`.
+ */
+export type VEAllowedCallback = 'setFix' | 'setMessage' | 'setProblem' | 'setTemplate';


### PR DESCRIPTION
## [2.0.0] - 2021-08-12

### 2.0.0 Added

- 069d111  
  Added static private property `#template` of a `string` type.  
  Added private instance `#callback` property of `Callback` instance.  
  Added private instance `#fix`,  `#problem`, `#tpl` property.  
  Added pubic methods `setFix()`, `setMessage()`, `setProblem()`,  `setTemplate()`, `throw()`, `updateMessage()` of an instance.  
  Added static private methods `#guardMessage()`, `#guardTemplate()`.  
- 4040750  
  Added an optional property `template` to the `ErrorMessage` interface.
- 0d5cc92  
  Added `VEAllowedCallback` type of allowed names for internal instance of `Callback`.

### 2.0.0 Changed

- 069d111  
  Changed static public `template` property to use static private `#template` property that is guarded by the private static `#guardTemplate()` method.  
  Changed instance `fix` property to use private `#fix`.  
  Changed instance `problem` property to use private `#problem`.  
  Changed public static `defineMessage()` method to use private static `#guardMessage()` to guards the provided `message`.  
  Changed constructor to use public `setMessage()` method and add new `callback` parameter to handle private instance of `Callback`.  
- 0708846 bcc6521 0bbd886  
  Updated `README.md`.

